### PR TITLE
Update "Item Type" sorting

### DIFF
--- a/SortaKinda/Models/Configuration/SortingRule.cs
+++ b/SortaKinda/Models/Configuration/SortingRule.cs
@@ -129,9 +129,42 @@ public unsafe class SortingRule : ISortingRule
         SortOrderMode.Alphabetically => string.Compare(firstItem.Name.RawString, secondItem.Name.RawString, StringComparison.OrdinalIgnoreCase) == 0,
         SortOrderMode.SellPrice => firstItem.PriceLow == secondItem.PriceLow,
         SortOrderMode.Rarity => firstItem.Rarity == secondItem.Rarity,
-        SortOrderMode.ItemType => firstItem.ItemUICategory.Row == secondItem.ItemUICategory.Row,
+        SortOrderMode.ItemType => ItemTypeSwap(firstItem, secondItem) == 0,
         _ => false
     };
+
+    private static int ItemTypeSwap(Item firstItem, Item secondItem)
+    {
+        switch (firstItem.ItemSortCategory.Value!.Param.CompareTo(secondItem.ItemSortCategory.Value!.Param))
+        {
+            case < 0: return -1;
+            case > 0: return 1;
+            default: break;
+        }
+
+        switch (ShouldSwapItemUiCategory(firstItem, secondItem))
+        {
+            case < 0: return -1;
+            case > 0: return 1;
+            default: break;
+        }
+
+        switch (firstItem.Unknown19.CompareTo(secondItem.Unknown19))
+        {
+            case < 0: return -1;
+            case > 0: return 1;
+            default: break;
+        }
+
+        switch (firstItem.RowId.CompareTo(secondItem.RowId))
+        {
+            case < 0: return -1;
+            case > 0: return 1;
+            default: break;
+        }
+
+        return 0;
+    }
 
     private static bool ShouldSwap(Item firstItem, Item secondItem, SortOrderMode sortMode) => sortMode switch
     {
@@ -140,25 +173,29 @@ public unsafe class SortingRule : ISortingRule
         SortOrderMode.Alphabetically => string.Compare(firstItem.Name.RawString, secondItem.Name.RawString, StringComparison.OrdinalIgnoreCase) > 0,
         SortOrderMode.SellPrice => firstItem.PriceLow > secondItem.PriceLow,
         SortOrderMode.Rarity => firstItem.Rarity > secondItem.Rarity,
-        SortOrderMode.ItemType => ShouldSwapItemUiCategory(firstItem, secondItem),
+        SortOrderMode.ItemType => ItemTypeSwap(firstItem, secondItem) > 0,
         _ => false
     };
 
-    private static bool ShouldSwapItemUiCategory(Item firstItem, Item secondItem)
+    private static int ShouldSwapItemUiCategory(Item firstItem, Item secondItem)
     {
-        // If same category, don't swap, other system handles fallback to alphabetical in this case
-        if (firstItem.ItemUICategory.Row == secondItem.ItemUICategory.Row) return false;
-
         if (firstItem is { ItemUICategory.Value: { } first } && secondItem is { ItemUICategory.Value: { } second })
         {
-            if (first.OrderMajor == second.OrderMajor)
+            switch (first.OrderMajor.CompareTo(second.OrderMajor))
             {
-                return first.OrderMinor > second.OrderMinor;
+                case < 0: return -1;
+                case > 0: return 1;
+                default: break;
             }
 
-            return first.OrderMajor > second.OrderMajor;
+            switch (first.OrderMinor.CompareTo(second.OrderMinor))
+            {
+                case < 0: return -1;
+                case > 0: return 1;
+                default: break;
+            }
         }
 
-        return false;
+        return 0;
     }
 }


### PR DESCRIPTION
Updated the "Item Type" sorting algorithm to be more in line like the base game's sort

Base:
![image](https://github.com/MidoriKami/SortaKinda/assets/24492062/41fb4d57-8628-4062-855e-2f80d38dea06)

Updated:
![image](https://github.com/MidoriKami/SortaKinda/assets/24492062/be7613ed-6645-459c-a1ec-2b6aa2555f66)

Current Item sort:
![image](https://github.com/MidoriKami/SortaKinda/assets/24492062/9b246c86-ac0a-4a1a-a032-1a0f4201f2b5)

Should hopefully keep raid/trial drops grouped and ordered together by tiers like the base game's sort.

The sort does rely on `Unknown19`, which seems to be something like a item order/grouping metric?