### PR TITLE
Support additional tie-breaker sort rules

### DIFF
--- a/SortaKinda/Classes/SortingRule.cs
+++ b/SortaKinda/Classes/SortingRule.cs
@@ -91,10 +91,7 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
     public SortOrderDirection Direction { get; set; } = SortOrderDirection.Ascending;
     public FillMode FillMode { get; set; } = FillMode.Top;
     public SortOrderMode SortMode { get; set; } = SortOrderMode.Alphabetically;
-    // Legacy field kept for config compatibility with builds that only supported additional sort modes without per-mode direction.
     public List<SortOrderMode> AdditionalSortModes { get; set; } = [];
-    // Additional sort criteria used as tie-breakers after SortMode.
-    // Each entry has its own direction, so tie-breakers can sort independently.
     public List<AdditionalSortRule> AdditionalSortRules { get; set; } = [];
     public bool InclusiveAnd = false;
 
@@ -107,8 +104,6 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
         if (y is null) return 0;
         if (x.ExdItem.RowId is 0) return 0;
         if (y.ExdItem.RowId is 0) return 0;
-        // Returning 0 means "equal for sorting purposes".
-        // We only do this when all configured sort modes tie.
         if (IsSortModeChainMatch(x.ExdItem, y.ExdItem)) return 0;
         if (CompareSlots(x, y)) return 1;
         return -1;
@@ -147,9 +142,7 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
                         shouldSwap = true;
                     }
                 }
-                // else they are not the same item, compare using configured sort chain and fallback ordering
                 else {
-                    // Primary mode decides first; additional modes are applied only when equal.
                     shouldSwap = ShouldSwapBySortChain(firstItem, secondItem);
                 }
 
@@ -161,8 +154,6 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
     }
     
     private bool IsSortModeChainMatch(Item firstItem, Item secondItem) {
-        // Chain match == all configured sort modes report "equal".
-        // This mirrors lexicographic sort behavior where each mode is a tie-breaker.
         foreach (var sortRule in GetSortModeChain()) {
             if (!IsSortMatch(firstItem, secondItem, sortRule.Mode)) return false;
         }
@@ -171,7 +162,6 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
     }
 
     private IEnumerable<AdditionalSortRule> GetSortModeChain() {
-        // Keep existing behavior: first mode is always the legacy SortMode with the main direction setting.
         yield return new AdditionalSortRule {
             Mode = SortMode,
             Direction = Direction
@@ -184,10 +174,6 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
     }
 
     private bool ShouldSwapBySortChain(Item firstItem, Item secondItem) {
-        // Lexicographic compare:
-        // 1) find first mode where values differ
-        // 2) use that mode to decide ordering
-        // 3) if every mode ties, use legacy alphabetical fallback
         foreach (var sortRule in GetSortModeChain()) {
             if (!IsSortMatch(firstItem, secondItem, sortRule.Mode)) {
                 var shouldSwap = ShouldSwap(firstItem, secondItem, sortRule.Mode);
@@ -195,22 +181,23 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
             }
         }
 
-        // If all configured modes tie, keep previous behavior and fall back to alphabetical.
         var shouldSwapFallback = ShouldSwap(firstItem, secondItem, SortOrderMode.Alphabetically);
         return Direction is SortOrderDirection.Descending ? !shouldSwapFallback : shouldSwapFallback;
     }
 
+    /*
+     * Backwards compatibility for older configs that only stored AdditionalSortModes.
+     * New builds store AdditionalSortRules (mode + per-mode direction). When legacy values
+     * are present and no new-format rules exist, migrate and clear the legacy list.
+     */
     public void MigrateLegacyAdditionalSortModes() {
-        // If there's no legacy data, there's nothing to migrate.
         if (AdditionalSortModes.Count is 0) return;
 
-        // If new-format rules already exist, treat them as authoritative and discard legacy duplicates.
         if (AdditionalSortRules.Count is not 0) {
             AdditionalSortModes.Clear();
             return;
         }
 
-        // Legacy entries inherit the current primary direction to preserve old behavior.
         foreach (var sortMode in AdditionalSortModes) {
             AdditionalSortRules.Add(new AdditionalSortRule {
                 Mode = sortMode,
@@ -218,7 +205,6 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
             });
         }
 
-        // Clear legacy data after successful migration.
         AdditionalSortModes.Clear();
     }
 

--- a/SortaKinda/Classes/SortingRule.cs
+++ b/SortaKinda/Classes/SortingRule.cs
@@ -91,6 +91,11 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
     public SortOrderDirection Direction { get; set; } = SortOrderDirection.Ascending;
     public FillMode FillMode { get; set; } = FillMode.Top;
     public SortOrderMode SortMode { get; set; } = SortOrderMode.Alphabetically;
+    // Legacy field kept for config compatibility with builds that only supported additional sort modes without per-mode direction.
+    public List<SortOrderMode> AdditionalSortModes { get; set; } = [];
+    // Additional sort criteria used as tie-breakers after SortMode.
+    // Each entry has its own direction, so tie-breakers can sort independently.
+    public List<AdditionalSortRule> AdditionalSortRules { get; set; } = [];
     public bool InclusiveAnd = false;
 
     public void ShowTooltip() {
@@ -102,7 +107,9 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
         if (y is null) return 0;
         if (x.ExdItem.RowId is 0) return 0;
         if (y.ExdItem.RowId is 0) return 0;
-        if (IsFilterMatch(x.ExdItem, y.ExdItem)) return 0;
+        // Returning 0 means "equal for sorting purposes".
+        // We only do this when all configured sort modes tie.
+        if (IsSortModeChainMatch(x.ExdItem, y.ExdItem)) return 0;
         if (CompareSlots(x, y)) return 1;
         return -1;
     }
@@ -140,23 +147,82 @@ public unsafe class SortingRule : IComparer<InventorySlot>{
                         shouldSwap = true;
                     }
                 }
-                // else if they match according to the default filter, fallback to alphabetical
-                else if (IsFilterMatch(firstItem, secondItem)) {
-                    shouldSwap = ShouldSwap(firstItem, secondItem, SortOrderMode.Alphabetically);
-                }
-                // else they are not the same item, and the filter result doesn't match
+                // else they are not the same item, compare using configured sort chain and fallback ordering
                 else {
-                    shouldSwap = ShouldSwap(firstItem, secondItem, SortMode);
+                    // Primary mode decides first; additional modes are applied only when equal.
+                    shouldSwap = ShouldSwapBySortChain(firstItem, secondItem);
                 }
-                
-                return Direction is SortOrderDirection.Descending ? !shouldSwap : shouldSwap;
+
+                return shouldSwap;
 
             // Something went horribly wrong... best not touch it and walk away.
             default: return false;
         }
     }
     
-    private bool IsFilterMatch(Item firstItem, Item secondItem) => SortMode switch {
+    private bool IsSortModeChainMatch(Item firstItem, Item secondItem) {
+        // Chain match == all configured sort modes report "equal".
+        // This mirrors lexicographic sort behavior where each mode is a tie-breaker.
+        foreach (var sortRule in GetSortModeChain()) {
+            if (!IsSortMatch(firstItem, secondItem, sortRule.Mode)) return false;
+        }
+
+        return true;
+    }
+
+    private IEnumerable<AdditionalSortRule> GetSortModeChain() {
+        // Keep existing behavior: first mode is always the legacy SortMode with the main direction setting.
+        yield return new AdditionalSortRule {
+            Mode = SortMode,
+            Direction = Direction
+        };
+
+        MigrateLegacyAdditionalSortModes();
+        foreach (var sortRule in AdditionalSortRules) {
+            yield return sortRule;
+        }
+    }
+
+    private bool ShouldSwapBySortChain(Item firstItem, Item secondItem) {
+        // Lexicographic compare:
+        // 1) find first mode where values differ
+        // 2) use that mode to decide ordering
+        // 3) if every mode ties, use legacy alphabetical fallback
+        foreach (var sortRule in GetSortModeChain()) {
+            if (!IsSortMatch(firstItem, secondItem, sortRule.Mode)) {
+                var shouldSwap = ShouldSwap(firstItem, secondItem, sortRule.Mode);
+                return sortRule.Direction is SortOrderDirection.Descending ? !shouldSwap : shouldSwap;
+            }
+        }
+
+        // If all configured modes tie, keep previous behavior and fall back to alphabetical.
+        var shouldSwapFallback = ShouldSwap(firstItem, secondItem, SortOrderMode.Alphabetically);
+        return Direction is SortOrderDirection.Descending ? !shouldSwapFallback : shouldSwapFallback;
+    }
+
+    public void MigrateLegacyAdditionalSortModes() {
+        // If there's no legacy data, there's nothing to migrate.
+        if (AdditionalSortModes.Count is 0) return;
+
+        // If new-format rules already exist, treat them as authoritative and discard legacy duplicates.
+        if (AdditionalSortRules.Count is not 0) {
+            AdditionalSortModes.Clear();
+            return;
+        }
+
+        // Legacy entries inherit the current primary direction to preserve old behavior.
+        foreach (var sortMode in AdditionalSortModes) {
+            AdditionalSortRules.Add(new AdditionalSortRule {
+                Mode = sortMode,
+                Direction = Direction
+            });
+        }
+
+        // Clear legacy data after successful migration.
+        AdditionalSortModes.Clear();
+    }
+
+    private static bool IsSortMatch(Item firstItem, Item secondItem, SortOrderMode sortMode) => sortMode switch {
         SortOrderMode.ItemId => firstItem.RowId == secondItem.RowId,
         SortOrderMode.ItemLevel => firstItem.LevelItem.RowId == secondItem.LevelItem.RowId,
         SortOrderMode.Alphabetically => string.Equals(firstItem.Name.ExtractText(), secondItem.Name.ExtractText(), StringComparison.OrdinalIgnoreCase),
@@ -254,4 +320,9 @@ public class SortingFilter {
     public required Func<bool> Active { get; init; }
     
     public required Func<InventorySlot, bool> IsSlotAllowed { get; init; }
+}
+
+public class AdditionalSortRule {
+    public SortOrderMode Mode { get; set; } = SortOrderMode.ItemId;
+    public SortOrderDirection Direction { get; set; } = SortOrderDirection.Ascending;
 }

--- a/SortaKinda/ViewComponents/SortingRuleTooltipView.cs
+++ b/SortaKinda/ViewComponents/SortingRuleTooltipView.cs
@@ -24,10 +24,13 @@ public class SortingRuleTooltipView(SortingRule sortingRule) {
         ImGui.Text(sortingRule.Name);
 
         if (sortingRule.Id is not SortController.DefaultId) {
+            // Keep tooltip output accurate for both legacy and new rule formats.
+            sortingRule.MigrateLegacyAdditionalSortModes();
             var itemFiltersString = GetAllowedItemsString();
+            var sortModeString = string.Join(" → ", new[] { $"{sortingRule.SortMode.GetDescription()} ({sortingRule.Direction.GetDescription()})" }.Concat(sortingRule.AdditionalSortRules.Select(sortRule => $"{sortRule.Mode.GetDescription()} ({sortRule.Direction.GetDescription()})")));
 
             ImGui.TextColored(KnownColor.Gray.Vector(), itemFiltersString.IsNullOrEmpty() ? "Any Item" : itemFiltersString);
-            ImGui.TextColored(KnownColor.Gray.Vector(), sortingRule.SortMode.GetDescription());
+            ImGui.TextColored(KnownColor.Gray.Vector(), sortModeString);
         }
 
         ImGui.EndTooltip();

--- a/SortaKinda/ViewComponents/SortingRuleView.cs
+++ b/SortaKinda/ViewComponents/SortingRuleView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Numerics;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Components;
@@ -202,27 +203,113 @@ public class ToggleFiltersTab(SortingRule rule) : IOneColumnRuleConfigurationTab
     }
 }
 
-public class SortOrderTab(SortingRule rule) : ITwoColumnRuleConfigurationTab {
+public class SortOrderTab(SortingRule rule) : IRuleConfigurationTab {
+    // UI-local selection used by the "Add Mode" button.
+    // The value is only persisted once added to AdditionalSortRules.
+    private SortOrderMode additionalSortMode = SortOrderMode.ItemId;
+    private SortOrderDirection additionalSortDirection = SortOrderDirection.Ascending;
+
     public string Name => "Sort Order";
     
     public bool Disabled => false;
     
     public SortingRule SortingRule { get; } = rule;
-    
-    public string FirstLabel => "Sort By";
-    
-    public string SecondLabel => "Sort Options";
 
-    public void DrawLeftSideContents() {
+    public void DrawConfigurationTab() {
+        EnsureWindowHeightForSortOrder();
+
+        // Read old config values once before drawing, so old rule exports continue to render correctly.
+        SortingRule.MigrateLegacyAdditionalSortModes();
+
+        var removeIndex = -1;
+        var moveUpIndex = -1;
+        var moveDownIndex = -1;
+
+        using var table = ImRaii.Table("##SortOrderPrimaryTable", 2, ImGuiTableFlags.SizingStretchSame | ImGuiTableFlags.BordersInnerV, ImGui.GetContentRegionAvail());
+        if (!table) return;
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted("Sort By");
+        ImGui.Separator();
+
+        ImGui.TableNextColumn();
+        ImGui.TextUnformatted("Sort Options");
+        ImGui.Separator();
+
+        ImGui.TableNextColumn();
+        DrawLeftSideContents();
+
+        ImGui.TableNextColumn();
+        DrawRightSideContents();
+
+        // Tie-breaker section.
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
+        ImGui.Text("Then by");
+        ImGuiComponents.HelpMarker("Additional sort modes are applied in order when earlier modes tie.");
+
+        ImGui.TableNextColumn();
+        ImGuiHelpers.ScaledDummy(1.0f);
+
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
+        ImGui.Separator();
+        ImGui.TableNextColumn();
+        ImGui.Separator();
+
+        if (SortingRule.AdditionalSortRules.Count is 0) {
+            ImGui.TableNextRow();
+            ImGui.TableNextColumn();
+            ImGui.TextColored(KnownColor.Orange.Vector(), "No additional modes");
+            ImGui.TableNextColumn();
+            ImGuiHelpers.ScaledDummy(1.0f);
+        }
+
+        for (var index = 0; index < SortingRule.AdditionalSortRules.Count; index++) {
+            ImGui.TableNextRow();
+
+            ImGui.TableNextColumn();
+            DrawAdditionalSortModeLeft(index, ref moveUpIndex, ref moveDownIndex, ref removeIndex);
+
+            ImGui.TableNextColumn();
+            DrawAdditionalSortModeRight(index);
+        }
+
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
+        ImGui.Separator();
+        ImGui.TableNextColumn();
+        ImGui.Separator();
+
+        ImGui.TableNextRow();
+        ImGui.TableNextColumn();
+        DrawAdditionalSortAddLeft();
+        ImGui.TableNextColumn();
+        DrawAdditionalSortAddRight();
+
+        // Apply queued list mutations after rendering to avoid mutating during iteration.
+        if (moveUpIndex > 0) {
+            (SortingRule.AdditionalSortRules[moveUpIndex - 1], SortingRule.AdditionalSortRules[moveUpIndex]) = (SortingRule.AdditionalSortRules[moveUpIndex], SortingRule.AdditionalSortRules[moveUpIndex - 1]);
+        }
+
+        if (moveDownIndex >= 0 && moveDownIndex < SortingRule.AdditionalSortRules.Count - 1) {
+            (SortingRule.AdditionalSortRules[moveDownIndex], SortingRule.AdditionalSortRules[moveDownIndex + 1]) = (SortingRule.AdditionalSortRules[moveDownIndex + 1], SortingRule.AdditionalSortRules[moveDownIndex]);
+        }
+
+        if (removeIndex >= 0 && removeIndex < SortingRule.AdditionalSortRules.Count) {
+            SortingRule.AdditionalSortRules.RemoveAt(removeIndex);
+        }
+    }
+
+    private void DrawLeftSideContents() {
         ImGui.Text("Order items using");
         ImGuiComponents.HelpMarker("The primary property of an item to use for ordering");
         var sortMode = SortingRule.SortMode;
         DrawRadioEnum(ref sortMode);
-
         SortingRule.SortMode = sortMode;
     }
 
-    public void DrawRightSideContents() {
+    private void DrawRightSideContents() {
         ImGui.Text("Sort item by");
         ImGuiComponents.HelpMarker("Ascending: A -> Z\nDescending Z -> A");
         var sortDirection = SortingRule.Direction;
@@ -244,6 +331,95 @@ public class SortOrderTab(SortingRule rule) : ITwoColumnRuleConfigurationTab {
             if (ImGui.RadioButton($"{value.GetDescription()}##{configValue.GetType()}", ref isSelected, Convert.ToInt32(value))) {
                 configValue = (T) value;
             }
+        }
+    }
+
+    private void DrawAdditionalSortModeLeft(int index, ref int moveUpIndex, ref int moveDownIndex, ref int removeIndex) {
+        var sortRule = SortingRule.AdditionalSortRules[index];
+        using var _ = ImRaii.PushId(index);
+
+        using (ImRaii.Disabled(index is 0)) {
+            if (ImGuiComponents.IconButton($"##AdditionalUp{index}", FontAwesomeIcon.ArrowUp)) {
+                moveUpIndex = index;
+            }
+        }
+
+        ImGui.SameLine();
+        using (ImRaii.Disabled(index == SortingRule.AdditionalSortRules.Count - 1)) {
+            if (ImGuiComponents.IconButton($"##AdditionalDown{index}", FontAwesomeIcon.ArrowDown)) {
+                moveDownIndex = index;
+            }
+        }
+
+        ImGui.SameLine();
+        if (ImGuiComponents.IconButton($"##AdditionalDelete{index}", FontAwesomeIcon.Trash)) {
+            removeIndex = index;
+        }
+
+        ImGui.SameLine();
+        ImGui.TextUnformatted(sortRule.Mode.GetDescription());
+    }
+
+    private void DrawAdditionalSortModeRight(int index) {
+        // Direction is stored per tie-breaker rule.
+        var direction = SortingRule.AdditionalSortRules[index].Direction;
+        if (ImGui.RadioButton($"Asc##AdditionalAsc{index}", direction is SortOrderDirection.Ascending)) {
+            SortingRule.AdditionalSortRules[index].Direction = SortOrderDirection.Ascending;
+        }
+
+        ImGui.SameLine();
+        if (ImGui.RadioButton($"Desc##AdditionalDesc{index}", direction is SortOrderDirection.Descending)) {
+            SortingRule.AdditionalSortRules[index].Direction = SortOrderDirection.Descending;
+        }
+    }
+
+    private void DrawAdditionalSortAddLeft() {
+        ImGui.SetNextItemWidth(-1.0f);
+        if (ImGui.BeginCombo("##AdditionalSortModeCombo", additionalSortMode.GetDescription())) {
+            foreach (var value in Enum.GetValues<SortOrderMode>()) {
+                if (ImGui.Selectable(value.GetDescription(), value == additionalSortMode)) {
+                    additionalSortMode = value;
+                }
+            }
+            ImGui.EndCombo();
+        }
+    }
+
+    private void DrawAdditionalSortAddRight() {
+        // Direction selected here becomes the default for the next added tie-breaker entry.
+        var newDirection = additionalSortDirection;
+        DrawSortDirectionRadioPair("##NewAdditionalDirection", ref newDirection, true);
+        additionalSortDirection = newDirection;
+
+        var buttonSize = ImGuiHelpers.ScaledVector2(85.0f, 0.0f);
+        ImGui.SameLine(ImGui.GetContentRegionAvail().X - buttonSize.X);
+        if (ImGui.Button("Add Mode", buttonSize)) {
+            SortingRule.AdditionalSortRules.Add(new AdditionalSortRule {
+                Mode = additionalSortMode,
+                Direction = additionalSortDirection
+            });
+        }
+    }
+
+    private static void DrawSortDirectionRadioPair(string id, ref SortOrderDirection direction, bool shortLabels) {
+        var ascLabel = shortLabels ? "Asc" : "Ascending";
+        var descLabel = shortLabels ? "Desc" : "Descending";
+
+        if (ImGui.RadioButton($"{ascLabel}##{id}Asc", direction is SortOrderDirection.Ascending)) {
+            direction = SortOrderDirection.Ascending;
+        }
+
+        ImGui.SameLine();
+        if (ImGui.RadioButton($"{descLabel}##{id}Desc", direction is SortOrderDirection.Descending)) {
+            direction = SortOrderDirection.Descending;
+        }
+    }
+
+    private static void EnsureWindowHeightForSortOrder() {
+        var minimumHeight = ImGuiHelpers.ScaledVector2(0.0f, 610.0f).Y;
+        var size = ImGui.GetWindowSize();
+        if (size.Y < minimumHeight) {
+            ImGui.SetWindowSize(new Vector2(size.X, minimumHeight));
         }
     }
 }

--- a/SortaKinda/Windows/TutorialWindow.cs
+++ b/SortaKinda/Windows/TutorialWindow.cs
@@ -95,6 +95,8 @@ public class TutorialConfiguringInventory : ITabItem {
                                           "The currently selected rule will have a filledin dot next to the color/name of the rule.\n\n" +
                                           "Once you have a rule selected you can 'paint' your inventory slots on the right side of the configuration window. Painted slots do not have to be adjacent to each other.\n\n" +
                                           "Whenever a sort is triggered, items that match the rules of a painted inventory slot will try to be moved into those inventory slots, and then re-ordered according to the rule's settings.\n" +
+                                          "In the Sort Order tab, 'Then by' can be used to add additional sort modes that act as tie-breakers.\n" +
+                                          "Tie-breakers are applied top-to-bottom and each one has its own Asc/Desc direction.\n" +
                                           "Items that don't match a rule but are in a rules inventory slots will be moved out into 'Unsorted' slots.\n\n" +
                                           "You must always have some inventory slots marked as 'Unsorted'.";
 }
@@ -118,6 +120,8 @@ public class TutorialAdvancedSorting : ITabItem {
                                         "this allows you to define rules in such a way that you can have items that match multiple rules always end up in one specific section of your inventory.\n\n" +
                                         "Rules are evaluated from the top of the list (where 'Unsorted' is), to the bottom of the list (where the add new rule button is), " +
                                         "If an item would be allowed by multiple rules, the rule lowest in the list will get the item in the end.\n\n" +
+                                        "Within a single rule, you can also chain sort modes with 'Then by' to get multi-criteria ordering.\n" +
+                                        "For example: Item Type -> Item Id -> Item Level, with independent Asc/Desc at each step.\n\n" +
                                         "You can use this characteristic of SortaKinda to define generalized sorting rules at the top of the list, and more specific sorting rules at the bottom of the list, " +
                                         "any items that match the more specific rules at the bottom will have the items in the end.\n\n" +
                                         "In other words, you can consider the order the rules are in to be a soft-priority system, where the rules on the bottom are more important.";


### PR DESCRIPTION
Introduce per-mode additional sort rules so multiple sort modes can be applied lexicographically with independent directions. Adds AdditionalSortRule and plumbing: GetSortModeChain, IsSortModeChainMatch, ShouldSwapBySortChain and MigrateLegacyAdditionalSortModes to keep config compatibility with the legacy AdditionalSortModes list (migrates and clears legacy data). Comparator logic now uses the sort-mode chain and falls back to alphabetical if all modes tie. UI and tooltip updated: SortOrderTab now exposes adding, reordering and removing tie-breaker modes with per-rule directions and the tooltip shows the full sort chain; also imports System.Numerics for window sizing. Overall this preserves legacy behavior while enabling multi-criteria sorting.

<img width="550" height="548" alt="image_2026-03-03_004049710" src="https://github.com/user-attachments/assets/d17ce20d-5251-4e50-ac89-5d0ac1445f19" />
