### PR TITLE
fix logic for allow/disallow

### DIFF
--- a/SortaKinda/FilterRules/FilteringRuleBase.cs
+++ b/SortaKinda/FilterRules/FilteringRuleBase.cs
@@ -32,5 +32,5 @@ public abstract unsafe partial class FilteringRuleBase {
 	/// Public function for evaluating if this item should be allowed.
 	/// </summary>
 	public bool IsItemAllowed(InventoryItem* item)
-		=> EvaluateItem(item) && IsAllowed;
+		=> EvaluateItem(item) == IsAllowed;
 }


### PR DESCRIPTION
Old
| `IsAllowed` | `EvaluateItem` | `IsItemAllowed` |
|---|---|---|
| `true` | `true` | `true` |
| `true` | `false` | `false` |
| `false` | `true` | `false` |
| `false` | `false` | `false` |

New
| `IsAllowed` | `EvaluateItem` | `IsItemAllowed` |
|---|---|---|
| `true` | `true` | `true` |
| `true` | `false` | `false` |
| `false` | `true` | `false` |
| `false` | `false` | `true` |