### PR TITLE
Add import support for legacy (pre-3.0) backup codes

### DIFF
--- a/SortaKinda/Classes/LegacyConfiguration.cs
+++ b/SortaKinda/Classes/LegacyConfiguration.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text.Json;
+
+namespace SortaKinda.Classes;
+
+/// <summary>
+/// Data-transfer objects that mirror the pre-3.0.0 ("2.x") SortaKinda export/config layout.
+/// These are only used to read legacy data so it can be migrated into the current model.
+/// </summary>
+internal class LegacyExport {
+	public List<LegacyRule> Rules { get; set; } = [];
+	public LegacyInventoryRoot? MainInventory { get; set; }
+	public LegacyInventoryRoot? Armory { get; set; }
+}
+
+internal class LegacyRule {
+	public Vector4 Color { get; set; } = Vector4.One;
+	public string Id { get; set; } = string.Empty;
+	public string Name { get; set; } = "New Rule";
+	public int Index { get; set; }
+
+	public List<JsonElement> AllowedNameRegexes { get; set; } = [];
+	public List<uint> AllowedItemTypes { get; set; } = [];
+	public List<uint> AllowedItemRarities { get; set; } = [];
+
+	public LegacyRangeFilter? LevelFilter { get; set; }
+	public LegacyRangeFilter? ItemLevelFilter { get; set; }
+	public LegacyRangeFilter? VendorPriceFilter { get; set; }
+
+	public LegacyToggleFilter? UntradableFilter { get; set; }
+	public LegacyToggleFilter? UniqueFilter { get; set; }
+	public LegacyToggleFilter? CollectableFilter { get; set; }
+	public LegacyToggleFilter? DyeableFilter { get; set; }
+	public LegacyToggleFilter? RepairableFilter { get; set; }
+
+	// 0 = Ascending, 1 = Descending
+	public int Direction { get; set; }
+
+	// 0 = Top, 1 = Bottom
+	public int FillMode { get; set; }
+
+	// SortOrderMode: 0 Alphabetical, 1 ItemLevel, 2 Rarity, 3 SellPrice, 4 ItemId, 5 ItemType, 6 Level(equip)
+	public int SortMode { get; set; }
+
+	public List<int> AdditionalSortModes { get; set; } = [];
+	public List<LegacyAdditionalSortRule> AdditionalSortRules { get; set; } = [];
+
+	public bool InclusiveAnd { get; set; }
+}
+
+internal class LegacyRangeFilter {
+	public bool Enable { get; set; }
+	public int MinValue { get; set; }
+	public int MaxValue { get; set; }
+}
+
+internal class LegacyToggleFilter {
+	// ToggleFilterState: 0 Ignored, 1 Allow, 2 Disallow
+	public int State { get; set; }
+	public int Filter { get; set; }
+}
+
+internal class LegacyAdditionalSortRule {
+	public int Mode { get; set; }
+	public int Direction { get; set; }
+}
+
+internal class LegacyInventoryRoot {
+	public List<LegacyInventoryConfig> InventoryConfigs { get; set; } = [];
+}
+
+internal class LegacyInventoryConfig {
+	public List<LegacySlotConfig> SlotConfigs { get; set; } = [];
+
+	// For main inventory this is 0-3 (Inventory1-4); for armory it is the raw InventoryType value.
+	public int Type { get; set; }
+}
+
+internal class LegacySlotConfig {
+	public string RuleId { get; set; } = string.Empty;
+}

--- a/SortaKinda/Classes/LegacyConfiguration.cs
+++ b/SortaKinda/Classes/LegacyConfiguration.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Text.Json;
 
+// ReSharper disable CollectionNeverUpdated.Global
+// Reason: Legacy Migration Support.
+
 namespace SortaKinda.Classes;
 
 /// <summary>

--- a/SortaKinda/Classes/LegacyPresetMigrator.cs
+++ b/SortaKinda/Classes/LegacyPresetMigrator.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using SortaKinda.Configuration;
+using SortaKinda.FilterRules;
+using SortaKinda.OrderRules;
+
+namespace SortaKinda.Classes;
+
+/// <summary>
+/// Converts a pre-3.0.0 ("2.x") SortaKinda export into the current configuration model.
+/// Used so old backup codes can still be imported seamlessly without any user interaction.
+/// </summary>
+internal static class LegacyPresetMigrator {
+	private const string DefaultRuleId = "Default";
+
+	// Namespace for stable GUIDs when a legacy rule id is not already a GUID string.
+	private static readonly Guid LegacyIdNamespace = new("8f4e2c1a-9b3d-4f6e-a5c8-2d7e9f0b1c3a");
+
+	private static readonly JsonSerializerOptions LegacyOptions = new() {
+		IncludeFields = true,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	/// <summary>
+	/// Returns true when the given JSON looks like a legacy (2.x) export rather than a current preset.
+	/// </summary>
+	public static bool IsLegacyFormat(string json) {
+		try {
+			using var document = JsonDocument.Parse(json);
+			var root = document.RootElement;
+
+			if (root.ValueKind is not JsonValueKind.Object) {
+				return false;
+			}
+
+			// Current presets are wrapped in a PresetContainer that has "RuleSets".
+			if (root.TryGetProperty("RuleSets", out _)) {
+				return false;
+			}
+
+			// Legacy exports always carry a flat "Rules" array.
+			return root.TryGetProperty("Rules", out var rules) && rules.ValueKind is JsonValueKind.Array;
+		}
+		catch (JsonException) {
+			return false;
+		}
+	}
+
+	public static bool TryParse(string json, out LegacyExport export) {
+		export = new LegacyExport();
+
+		try {
+			if (JsonSerializer.Deserialize<LegacyExport>(json, LegacyOptions) is { } parsed) {
+				export = parsed;
+				return export.Rules.Count > 0;
+			}
+		}
+		catch (JsonException e) {
+			Services.PluginLog.Error(e, "Failed to parse legacy SortaKinda export.");
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Converts every legacy rule into a current <see cref="RuleSet"/>.
+	/// </summary>
+	public static List<RuleSet> BuildRuleSets(LegacyExport export)
+		=> export.Rules
+			.Where(IsImportableLegacyRule)
+			.Select(BuildRuleSet)
+			.ToList();
+
+	private static bool IsImportableLegacyRule(LegacyRule rule)
+		=> !string.IsNullOrWhiteSpace(rule.Id) && !string.Equals(rule.Id, DefaultRuleId, StringComparison.Ordinal);
+
+	private static RuleSet BuildRuleSet(LegacyRule rule) {
+		var ruleSet = new RuleSet {
+			Name = rule.Name,
+			RuleSetId = ParseLegacyId(rule.Id),
+			Color = rule.Color,
+			RequireAll = !rule.InclusiveAnd,
+			ReverseFill = rule.FillMode == 1,
+			FilterRules = BuildFilterRules(rule),
+			OrderingRules = BuildOrderingRules(rule),
+		};
+
+		return ruleSet;
+	}
+
+	private static List<FilteringRuleBase> BuildFilterRules(LegacyRule rule) {
+		var filters = new List<FilteringRuleBase>();
+
+		if (rule.AllowedItemTypes.Count > 0) {
+			filters.Add(new ItemUiCategoryFilter {
+				ItemUiCategories = rule.AllowedItemTypes.ToList(),
+			});
+		}
+
+		var names = ExtractRegexStrings(rule.AllowedNameRegexes);
+		if (names.Count > 0) {
+			filters.Add(new NameFilter {
+				Names = names,
+			});
+		}
+
+		if (rule.AllowedItemRarities.Count > 0) {
+			filters.Add(new RarityFilter {
+				Rarities = rule.AllowedItemRarities.ToList(),
+			});
+		}
+
+		if (rule.LevelFilter is { Enable: true } equipLevel) {
+			filters.Add(new EquipLevelFilter {
+				MinLevel = ToUInt(equipLevel.MinValue),
+				MaxLevel = ToUInt(equipLevel.MaxValue),
+			});
+		}
+
+		if (rule.ItemLevelFilter is { Enable: true } itemLevel) {
+			filters.Add(new ItemLevelFilter {
+				MinLevel = ToUInt(itemLevel.MinValue),
+				MaxLevel = ToUInt(itemLevel.MaxValue),
+			});
+		}
+
+		if (rule.VendorPriceFilter is { Enable: true } vendorPrice) {
+			filters.Add(new VendorPriceFilter {
+				MinPrice = ToUInt(vendorPrice.MinValue),
+				MaxPrice = ToUInt(vendorPrice.MaxValue),
+			});
+		}
+
+		AddToggleFilter(filters, rule.UntradableFilter, static () => new UntradableFilter());
+		AddToggleFilter(filters, rule.UniqueFilter, static () => new UniqueFilter());
+		AddToggleFilter(filters, rule.CollectableFilter, static () => new CollectableFilter());
+		AddToggleFilter(filters, rule.DyeableFilter, static () => new DyeableFilter());
+		AddToggleFilter(filters, rule.RepairableFilter, static () => new RepairableFilter());
+
+		return filters;
+	}
+
+	private static void AddToggleFilter(List<FilteringRuleBase> filters, LegacyToggleFilter? toggle, Func<FilteringRuleBase> factory) {
+		// State: 0 = Ignored (skip), 1 = Allow, 2 = Disallow
+		if (toggle is null || toggle.State == 0) {
+			return;
+		}
+
+		var filter = factory();
+		filter.IsAllowed = toggle.State == 1;
+		filters.Add(filter);
+	}
+
+	private static List<OrderingRuleBase> BuildOrderingRules(LegacyRule rule) {
+		var orderings = new List<OrderingRuleBase>();
+
+		AddOrdering(orderings, rule.SortMode, rule.Direction);
+
+		if (rule.AdditionalSortRules.Count > 0) {
+			foreach (var additional in rule.AdditionalSortRules) {
+				AddOrdering(orderings, additional.Mode, additional.Direction);
+			}
+		}
+		else {
+			// Older configs stored only modes and reused the primary direction.
+			foreach (var mode in rule.AdditionalSortModes) {
+				AddOrdering(orderings, mode, rule.Direction);
+			}
+		}
+
+		return orderings;
+	}
+
+	private static void AddOrdering(List<OrderingRuleBase> orderings, int sortMode, int direction) {
+		if (CreateOrdering(sortMode, direction) is not { } ordering) {
+			return;
+		}
+
+		// The current UI only allows one ordering of each type; mirror that here.
+		if (orderings.Any(existing => existing.GetType() == ordering.GetType())) {
+			return;
+		}
+
+		orderings.Add(ordering);
+	}
+
+	private static OrderingRuleBase? CreateOrdering(int sortMode, int direction) {
+		// In the legacy model Ascending (0) always meant "low value first" and
+		// Descending (1) "high value first". Each current ordering has its own default
+		// direction, so we flip IsReversed only when the defaults disagree.
+		var wantDescending = direction == 1;
+
+		var (ordering, defaultIsDescending) = sortMode switch {
+			0 => ((OrderingRuleBase)new AlphabeticalOrdering(), false),
+			1 => (new ItemLevelOrdering(), true),
+			2 => (new RarityOrdering(), false),
+			3 => (new SellPriceOrdering(), false),
+			4 => (new ItemIdOrdering(), true),
+			5 => (new ItemUiCategoryOrdering(), false),
+			6 => (new EquipLevelOrdering(), true),
+			_ => (null!, false),
+		};
+
+		if (ordering is null) {
+			return null;
+		}
+
+		ordering.IsReversed = wantDescending != defaultIsDescending;
+		return ordering;
+	}
+
+	/// <summary>
+	/// Rebuilds the per-inventory slot layout from a legacy export, keyed by inventory type.
+	/// Only rule ids present in <paramref name="knownRuleSetIds"/> are kept.
+	/// </summary>
+	public static Dictionary<InventoryType, List<SlotSet>> BuildSlotSets(LegacyExport export, HashSet<Guid> knownRuleSetIds) {
+		var result = new Dictionary<InventoryType, List<SlotSet>>();
+		var rulePriorities = export.Rules
+			.Where(IsImportableLegacyRule)
+			.Select(rule => (RuleSetId: ParseLegacyId(rule.Id), rule.Index))
+			.ToDictionary(entry => entry.RuleSetId, entry => entry.Index);
+
+		AddInventoryRoot(result, export.MainInventory, knownRuleSetIds, rulePriorities);
+		AddInventoryRoot(result, export.Armory, knownRuleSetIds, rulePriorities);
+
+		return result;
+	}
+
+	private static void AddInventoryRoot(
+		Dictionary<InventoryType, List<SlotSet>> result,
+		LegacyInventoryRoot? root,
+		HashSet<Guid> knownRuleSetIds,
+		Dictionary<Guid, int> rulePriorities
+		)
+	{
+		if (root is null) {
+			return;
+		}
+
+		foreach (var config in root.InventoryConfigs) {
+			var inventoryType = (InventoryType)config.Type;
+			if (!System.AllowedInventories.Contains(inventoryType)) {
+				continue;
+			}
+
+			var slotSets = new List<SlotSet>();
+
+			var groupedSlots = config.SlotConfigs
+				.Select((slot, index) => (slot.RuleId, index))
+				.Where(entry => !string.IsNullOrEmpty(entry.RuleId) && entry.RuleId != DefaultRuleId)
+				.GroupBy(entry => entry.RuleId);
+
+			foreach (var group in groupedSlots) {
+				var ruleSetId = ParseLegacyId(group.Key);
+
+				if (!knownRuleSetIds.Contains(ruleSetId)) {
+					continue;
+				}
+
+				slotSets.Add(new SlotSet {
+					InventoryType = inventoryType,
+					RuleSetId = ruleSetId,
+					SlotIndexes = group.Select(entry => entry.index).ToList(),
+					Priority = rulePriorities.GetValueOrDefault(ruleSetId),
+				});
+			}
+
+			if (slotSets.Count > 0) {
+				result[inventoryType] = slotSets;
+			}
+		}
+	}
+
+	private static List<string> ExtractRegexStrings(List<JsonElement> elements) {
+		var results = new List<string>();
+
+		foreach (var element in elements) {
+			switch (element.ValueKind) {
+				case JsonValueKind.String when element.GetString() is { Length: > 0 } stringValue:
+					TryAddValidRegex(results, stringValue);
+					break;
+
+				case JsonValueKind.Object: {
+					foreach (var propertyName in (string[]) ["RegexString", "Regex", "Pattern", "Value"]) {
+						if (element.TryGetProperty(propertyName, out var property)
+						    && property.ValueKind is JsonValueKind.String
+						    && property.GetString() is { Length: > 0 } objectValue) {
+							TryAddValidRegex(results, objectValue);
+							break;
+						}
+					}
+
+					break;
+				}
+			}
+		}
+
+		return results;
+	}
+
+	private static void TryAddValidRegex(List<string> results, string pattern) {
+		if (!IsValidRegexPattern(pattern)) {
+			Services.PluginLog.Warning($"Skipping invalid legacy name regex during import: {pattern}");
+			return;
+		}
+
+		results.Add(pattern);
+	}
+
+	private static bool IsValidRegexPattern(string pattern) {
+		try {
+			_ = new Regex(pattern);
+			return true;
+		}
+		catch (ArgumentException) {
+			return false;
+		}
+	}
+
+	private static Guid ParseLegacyId(string id) {
+		if (Guid.TryParse(id, out var guid)) {
+			return guid;
+		}
+
+		var hash = MD5.HashData(Encoding.UTF8.GetBytes($"{LegacyIdNamespace:N}:{id}"));
+		hash[6] = (byte)((hash[6] & 0x0F) | 0x30);
+		hash[8] = (byte)((hash[8] & 0x3F) | 0x80);
+		return new Guid(hash);
+	}
+
+	private static uint ToUInt(int value)
+		=> value < 0 ? 0u : (uint)value;
+}

--- a/SortaKinda/Classes/LegacyPresetMigrator.cs
+++ b/SortaKinda/Classes/LegacyPresetMigrator.cs
@@ -20,6 +20,7 @@ internal static class LegacyPresetMigrator {
 	private const string DefaultRuleId = "Default";
 
 	// Namespace for stable GUIDs when a legacy rule id is not already a GUID string.
+	// Used as a base id that is mutated when importing individual rules.
 	private static readonly Guid LegacyIdNamespace = new("8f4e2c1a-9b3d-4f6e-a5c8-2d7e9f0b1c3a");
 
 	private static readonly JsonSerializerOptions LegacyOptions = new() {
@@ -80,19 +81,15 @@ internal static class LegacyPresetMigrator {
 	private static bool IsImportableLegacyRule(LegacyRule rule)
 		=> !string.IsNullOrWhiteSpace(rule.Id) && !string.Equals(rule.Id, DefaultRuleId, StringComparison.Ordinal);
 
-	private static RuleSet BuildRuleSet(LegacyRule rule) {
-		var ruleSet = new RuleSet {
-			Name = rule.Name,
-			RuleSetId = ParseLegacyId(rule.Id),
-			Color = rule.Color,
-			RequireAll = !rule.InclusiveAnd,
-			ReverseFill = rule.FillMode == 1,
-			FilterRules = BuildFilterRules(rule),
-			OrderingRules = BuildOrderingRules(rule),
-		};
-
-		return ruleSet;
-	}
+	private static RuleSet BuildRuleSet(LegacyRule rule) => new() {
+		Name = rule.Name,
+		RuleSetId = ParseLegacyId(rule.Id),
+		Color = rule.Color,
+		RequireAll = !rule.InclusiveAnd,
+		ReverseFill = rule.FillMode == 1,
+		FilterRules = BuildFilterRules(rule),
+		OrderingRules = BuildOrderingRules(rule),
+	};
 
 	private static List<FilteringRuleBase> BuildFilterRules(LegacyRule rule) {
 		var filters = new List<FilteringRuleBase>();
@@ -204,7 +201,7 @@ internal static class LegacyPresetMigrator {
 			4 => (new ItemIdOrdering(), true),
 			5 => (new ItemUiCategoryOrdering(), false),
 			6 => (new EquipLevelOrdering(), true),
-			_ => (null!, false),
+			_ => (null, false),
 		};
 
 		if (ordering is null) {
@@ -329,8 +326,8 @@ internal static class LegacyPresetMigrator {
 		}
 
 		var hash = MD5.HashData(Encoding.UTF8.GetBytes($"{LegacyIdNamespace:N}:{id}"));
-		hash[6] = (byte)((hash[6] & 0x0F) | 0x30);
-		hash[8] = (byte)((hash[8] & 0x3F) | 0x80);
+		hash[6] = (byte)(hash[6] & 0x0F | 0x30);
+		hash[8] = (byte)(hash[8] & 0x3F | 0x80);
 		return new Guid(hash);
 	}
 

--- a/SortaKinda/Classes/PresetManager.cs
+++ b/SortaKinda/Classes/PresetManager.cs
@@ -186,11 +186,9 @@ public static class PresetManager {
 		ImGui.SetClipboardText(Convert.ToBase64String(compressed));
 	}
 
-	private static PresetContainer CreatePresetContainer(IEnumerable<RuleSet> ruleSets) {
-		return new PresetContainer {
-			RuleSets = ruleSets
-				.Where(ruleSet => ruleSet.RuleSetId != SlotSet.IgnoreSlotsId)
-				.ToList(),
-		};
-	}
+	private static PresetContainer CreatePresetContainer(IEnumerable<RuleSet> ruleSets) => new() {
+		RuleSets = ruleSets
+			.Where(ruleSet => ruleSet.RuleSetId != SlotSet.IgnoreSlotsId)
+			.ToList(),
+	};
 }

--- a/SortaKinda/Classes/PresetManager.cs
+++ b/SortaKinda/Classes/PresetManager.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Utility;
+using SortaKinda.Configuration;
 
 namespace SortaKinda.Classes;
 
@@ -27,7 +29,16 @@ public static class PresetManager {
 				return;
 			}
 
+			// Older (pre-3.0.0) backup codes use a different layout. Detect and convert them
+			// transparently so the user never has to pick a format or know the difference.
+			if (LegacyPresetMigrator.IsLegacyFormat(uncompressed)) {
+				HandleLegacyImport(uncompressed);
+				return;
+			}
+
 			if (JsonSerializer.Deserialize<PresetContainer>(uncompressed, SerializerOptions) is { } clipboardData) {
+				clipboardData.RuleSets.RemoveAll(ruleSet => ruleSet.RuleSetId == SlotSet.IgnoreSlotsId);
+
 				if (clipboardData.RuleSets.Count is 0) {
 					Services.ChatGui.PrintError("[Import] Tried to import sorting rules, but got nothing, try copying the code again.", "SortaKinda");
 					return;
@@ -63,18 +74,123 @@ public static class PresetManager {
 	}
 
 	/// <summary>
+	/// Converts a legacy (2.x) backup code into the current model and imports it,
+	/// restoring both the sorting rules and (when logged in) the slot layout.
+	/// </summary>
+	private static void HandleLegacyImport(string json) {
+		if (!LegacyPresetMigrator.TryParse(json, out var legacyExport)) {
+			Services.ChatGui.PrintError("[Import] Tried to import an older backup code, but couldn't read any rules from it.", "SortaKinda");
+			return;
+		}
+
+		var migratedRuleSets = LegacyPresetMigrator.BuildRuleSets(legacyExport);
+
+		foreach (var ruleSet in migratedRuleSets) {
+			ruleSet.FilterRules
+			       .RemoveAll(filter => !filter.IsValid);
+
+			ruleSet.OrderingRules
+			       .RemoveAll(ordering => !ordering.IsValid);
+		}
+
+		// A rule with no filters used to mean "match every item" in the old version. That behavior
+		// is intentionally unsupported now, so any such rule is dropped and reported to the user.
+		var droppedRuleSets = migratedRuleSets
+			.Where(ruleSet => ruleSet.FilterRules.Count is 0)
+			.ToList();
+
+		var importableRuleSets = migratedRuleSets
+			.Where(ruleSet => ruleSet.FilterRules.Count > 0)
+			.ToList();
+
+		var addedCount = 0;
+		var updatedCount = 0;
+		foreach (var ruleSet in importableRuleSets) {
+			var existingIndex = System.SystemConfiguration.RuleSets.FindIndex(existingRule => existingRule.RuleSetId == ruleSet.RuleSetId);
+			if (existingIndex >= 0) {
+				System.SystemConfiguration.RuleSets[existingIndex] = ruleSet;
+				updatedCount++;
+			}
+			else {
+				System.SystemConfiguration.RuleSets.Add(ruleSet);
+				addedCount++;
+			}
+		}
+
+		var inventoriesRestored = ApplyLegacySlotLayout(legacyExport);
+
+		System.SystemConfiguration.Save(false);
+		CopyToClipboard(importableRuleSets);
+
+		Services.ChatGui.Print("[Import] Detected an older SortaKinda backup code and converted it automatically.", "SortaKinda");
+		Services.ChatGui.Print($"[Import] Added {addedCount} new sorting rules and updated {updatedCount} existing rules (backup contained {migratedRuleSets.Count}).", "SortaKinda");
+
+		foreach (var dropped in droppedRuleSets) {
+			Services.ChatGui.PrintError($"[Import] Rule Set '{dropped.Name}' was dropped because it had no filters. The old 'match all items' behavior is no longer supported.", "SortaKinda");
+		}
+
+		Services.ChatGui.Print("[Import] Replaced the clipboard contents with a new-format backup code.", "SortaKinda");
+
+		if (inventoriesRestored > 0) {
+			Services.ChatGui.Print($"[Import] Restored slot assignments for {inventoriesRestored} inventories.", "SortaKinda");
+		}
+	}
+
+	/// <summary>
+	/// Rebuilds the current character's slot layout from a legacy export. Requires a logged in character.
+	/// </summary>
+	/// <returns>The number of inventories that had their slot assignments restored.</returns>
+	private static int ApplyLegacySlotLayout(LegacyExport legacyExport) {
+		if (System.CharacterConfiguration is not { } characterConfiguration) {
+			return 0;
+		}
+
+		var knownRuleSetIds = System.SystemConfiguration.RuleSets
+			.Select(ruleSet => ruleSet.RuleSetId)
+			.ToHashSet();
+
+		var migratedSlotSets = LegacyPresetMigrator.BuildSlotSets(legacyExport, knownRuleSetIds);
+		if (migratedSlotSets.Count is 0) {
+			return 0;
+		}
+
+		foreach (var (inventoryType, slotSets) in migratedSlotSets) {
+			if (!characterConfiguration.Inventories.TryGetValue(inventoryType, out var inventoryConfig)) {
+				inventoryConfig = new InventoryConfig();
+				characterConfiguration.Inventories[inventoryType] = inventoryConfig;
+			}
+
+			inventoryConfig.SlotSets = slotSets;
+		}
+
+		characterConfiguration.Save();
+		return migratedSlotSets.Count;
+	}
+
+	/// <summary>
 	/// Saves all the current rulesets to encoded text data to clipboard
 	/// </summary>
 	public static void SaveToClipboard() {
-		var data = new PresetContainer {
-			RuleSets = System.SystemConfiguration.RuleSets,
-		};
+		var data = CreatePresetContainer(System.SystemConfiguration.RuleSets
+			.Where(ruleSet => ruleSet.RuleSetId != SlotSet.IgnoreSlotsId));
 
+		CopyToClipboard(data.RuleSets);
+		Services.ChatGui.Print($"[Export] Exported {data.RuleSets.Count} rules to clipboard.", "SortaKinda");
+	}
+
+	private static void CopyToClipboard(IEnumerable<RuleSet> ruleSets) {
+		var data = CreatePresetContainer(ruleSets);
 		var jsonString = JsonSerializer.Serialize(data, SerializerOptions);
 
 		var compressed = Util.CompressString(jsonString);
 		ImGui.SetClipboardText(Convert.ToBase64String(compressed));
+	}
 
-		Services.ChatGui.Print($"[Export] Exported {data.RuleSets.Count} rules to clipboard.", "SortaKinda");
+	private static PresetContainer CreatePresetContainer(IEnumerable<RuleSet> ruleSets) {
+		return new PresetContainer {
+			RuleSets = ruleSets
+				.Where(ruleSet => ruleSet.RuleSetId != SlotSet.IgnoreSlotsId)
+				.ToList(),
+		};
 	}
 }

--- a/SortaKinda/OrderRules/EquipLevelOrdering.cs
+++ b/SortaKinda/OrderRules/EquipLevelOrdering.cs
@@ -1,0 +1,17 @@
+using FFXIVClientStructs.FFXIV.Client.Game;
+
+namespace SortaKinda.OrderRules;
+
+public class EquipLevelOrdering : OrderingRuleBase {
+	public override string Label
+		=> "Equip Level";
+
+	protected override string NotReversedLabel
+		=> "High";
+
+	protected override string ReversedLabel
+		=> "Low";
+
+	public override unsafe int Compare(InventoryItem* left, InventoryItem* right)
+		=> right->EquipLevel.CompareTo(left->EquipLevel);
+}


### PR DESCRIPTION
Old backup codes use the pre-rework layout and can no longer be imported. This detects them automatically on paste and converts them into the current rule sets, including the per-character slot layout, with no extra prompt.

Also adds an Equip Level ordering to cover the old equip-level sort that had no current equivalent. Legacy rules that relied on the old no-filter match-everything behavior are skipped on import and reported in chat. Export continues to emit only the current format.