### PR TITLE
Add setting to toggle aborted sorting warnings

### DIFF
--- a/SortaKinda/Classes/SortingController.cs
+++ b/SortaKinda/Classes/SortingController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -245,8 +245,12 @@ public unsafe class SortingController :  IDisposable {
 								}
 								else {
 									Services.PluginLog.Warning($"Failed to move '{itemForSlot->Name}' from '{slot}' to an empty slot in {adjustedInventoryType.AdjustedName} for {slotSet.RuleSet.Name}.");
-									Services.ChatGui.PrintError($"Failed to move '{itemForSlot->Name}' from '{slot}' in '{inventoryType}' to an empty slot in {adjustedInventoryType.AdjustedName} for {slotSet.RuleSet.Name}.");
-									Services.ChatGui.PrintError($"There needs to be unassigned slots for items to be moved to. Sorting for {slotSet.RuleSet.Name} has been aborted.", "SortaKinda");
+									
+									// Only print warnings to the chat if the corresponding configuration is enabled.
+									if (System.SystemConfiguration.EnableAbortedSortWarning) {
+										Services.ChatGui.PrintError($"Failed to move '{itemForSlot->Name}' from '{slot}' in '{inventoryType}' to an empty slot in {adjustedInventoryType.AdjustedName} for {slotSet.RuleSet.Name}.");
+										Services.ChatGui.PrintError($"There needs to be unassigned slots for items to be moved to. Sorting for {slotSet.RuleSet.Name} has been aborted.", "SortaKinda");
+									}
 									isError = true;
 								}
 							}

--- a/SortaKinda/Configuration/SystemConfiguration.cs
+++ b/SortaKinda/Configuration/SystemConfiguration.cs
@@ -26,6 +26,7 @@ public class SystemConfiguration {
 	public bool SortOnConfigChange = true;
 
 	public bool EnableSortLogging = false;
+	public bool EnableAbortedSortWarning = true;
 
 	public bool EnableUnassignedOrdering = false;
 	public OrderingRuleBase UnassignedSlotOrdering = new AlphabeticalOrdering();

--- a/SortaKinda/Windows/UiParts/GeneralConfiguration.cs
+++ b/SortaKinda/Windows/UiParts/GeneralConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
@@ -30,6 +30,7 @@ public static class GeneralConfiguration {
 		ImGui.Separator();
 
 		configChanged |= ImGui.Checkbox("Enable Advanced Logging", ref config.EnableSortLogging);
+		configChanged |= ImGui.Checkbox("Enable Aborted Sort Warning", ref config.EnableAbortedSortWarning);
 
 		ImGuiHelpers.ScaledDummy(10.0f);
 		ImGui.Text("Unassigned Slot Ordering");


### PR DESCRIPTION
Adds a config option under Advanced settings to toggle/hide the "needs to be unassigned slots for items to be moved to" warnings due to chat spam. 

The abort messages are still logged to the plugin log.